### PR TITLE
cabalized build

### DIFF
--- a/cinder.cabal
+++ b/cinder.cabal
@@ -1,5 +1,5 @@
 name:                cinder
-version:             0.1
+version:             0.4
 synopsis:            HTML and SVG Manipulation library for Fay
 description:         HTML and SVG Manipulation library for Fay
 homepage:            https://github.com/crooney/cinder
@@ -7,7 +7,7 @@ bug-reports:         https://github.com/crooney/cinder/issues
 license:             BSD3
 license-file:        LICENSE
 author:              Christopher Rooney
-copyright:           2013 Christopher Rooney
+copyright:           2013-2014 Christopher Rooney
 category:            Web, Fay
 build-type:          Simple
 cabal-version:       >=1.8

--- a/cinder.cabal
+++ b/cinder.cabal
@@ -1,0 +1,44 @@
+name:                cinder
+version:             0.1
+synopsis:            HTML and SVG Manipulation library for Fay
+description:         HTML and SVG Manipulation library for Fay
+homepage:            https://github.com/crooney/cinder
+bug-reports:         https://github.com/crooney/cinder/issues
+license:             BSD3
+license-file:        LICENSE
+author:              Christopher Rooney
+copyright:           2013 Christopher Rooney
+category:            Web, Fay
+build-type:          Simple
+cabal-version:       >=1.8
+extra-source-files:
+  LICENSE
+  README.md
+  CHANGELOG.md
+data-files: src/Cinder/DOM.hs
+            src/Cinder/SVG.hs
+            src/Cinder/HTML.hs
+            src/Cinder/HTML/Attributes.hs
+            src/Cinder/HTML/Elements.hs
+            src/Cinder/SVG/Attributes.hs
+            src/Cinder/SVG/Elements.hs
+            src/Cinder/DSL.hs
+
+source-repository head
+  type: git
+  location: https://github.com/crooney/cinder
+
+library
+  hs-source-dirs: src
+  exposed-modules: Cinder.DOM
+                   Cinder.SVG
+                   Cinder.HTML
+                   Cinder.HTML.Attributes
+                   Cinder.HTML.Elements
+                   Cinder.SVG.Attributes
+                   Cinder.SVG.Elements
+                   Cinder.DSL
+  ghc-options: -Wall
+  build-depends:
+    fay-base >= 0.19,
+    fay-text >= 0.3

--- a/src/Cinder/DOM.hs
+++ b/src/Cinder/DOM.hs
@@ -1,9 +1,10 @@
+{-# LANGUAGE EmptyDataDecls #-}
 module Cinder.DOM (module Cinder.DOM, module Cinder.DSL) where
 
-import Prelude
-import FFI
-import Control.Fay (foldM)
-import Cinder.DSL
+import           Cinder.DSL
+import           Control.Fay (foldM)
+import           FFI
+import           Prelude
 
 data Node
 

--- a/src/Cinder/SVG.hs
+++ b/src/Cinder/SVG.hs
@@ -2,13 +2,13 @@ module Cinder.SVG
     (module Cinder.SVG, module Cinder.DOM, module Cinder.DSL)
     where
 
-import Prelude hiding (min, max)
-import FFI
-import Control.Fay
-import Cinder.DSL
-import Cinder.DOM
-import Cinder.SVG.Attributes hiding (path)
-import Cinder.SVG.Elements
+import           Cinder.DOM
+import           Cinder.DSL
+import           Cinder.SVG.Attributes hiding (path)
+import           Cinder.SVG.Elements
+import           Control.Fay
+import           FFI
+import           Prelude               hiding (max, min)
 
 xmlns :: String
 xmlns = "http://www.w3.org/2000/svg"
@@ -199,8 +199,8 @@ slowDown = ksC "0 .2 .8 1"
 -- animate tracing path with current stroke for r repetitions of d duration
 -- l = path length. Pure func called from tracePath
 trace :: Double -> Double -> Double -> Markup
-trace d r l = markup ! strokeDashoffset (show l)
-              ! strokeDasharray (show l ++ "," ++ show l)
+trace d r l = markup ! strokeudashoffset (show l)
+              ! strokeudasharray (show l ++ "," ++ show l)
               !+ aADR "stroke-dashoffset" d r ! fill "freeze" !+ ftN l 0
 
 --non-pure SVG specific stuff (animations and namespaces, mostly)

--- a/src/Control/Fay.hs
+++ b/src/Control/Fay.hs
@@ -9,8 +9,8 @@ module Control.Fay
     )
     where
 
-import Prelude
-import FFI
+import           FFI
+import           Prelude hiding (mapM)
 
 ap :: Fay (a -> b) -> Fay a -> Fay b
 ap f x = f >>= \f' -> x >>= \x' -> return (f' x')

--- a/util/combos.sh
+++ b/util/combos.sh
@@ -11,18 +11,28 @@ DIR="../src/Cinder/${i}/"
 
 mkdir -p $DIR
 
-echo "module Cinder.${i}.Attributes where\nimport Cinder.DSL\n\n" \
+echo "module Cinder.${i}.Attributes where
+import Cinder.DSL
+
+" \
 	>$DIR/Attributes.hs
 
 cat "${i}attributes.txt" | sort | uniq | sed 'h;s/[-:]\(.\)/\u\1/g;G' \
-	| sed -n 'N;s/\(.*\)\n\(.*\)/\1 :: String -> Primitive\n\1 = Attribute "\2"\n/p;' \
+	| sed -n 'N;s/\(.*\)\n\(.*\)/\1 :: String -> Primitive\
+\1 = Attribute "\2"\
+/p;' \
 	>>$DIR/Attributes.hs
 
-echo "module Cinder.${i}.Elements where\nimport Cinder.DSL\n\n" \
+echo "module Cinder.${i}.Elements where
+import Cinder.DSL
+
+" \
 	>$DIR/Elements.hs
 
 cat "${i}elements.txt" | sort | uniq | sed 'h;s/[-:]\(.\)/\u\1/g;G' \
-	| sed -n 'N;s/\(.*\)\n\(.*\)/\1 :: Primitive\n\1 = Element "\2"\n/p;' \
+	| sed -n 'N;s/\(.*\)\n\(.*\)/\1 :: Primitive\
+\1 = Element "\2"\
+/p;' \
 	>>$DIR/Elements.hs
 
 done


### PR DESCRIPTION
- Added `cinder.cabal` file, cinder now builds as a cabal package and could be used as "normal" package dependencies from fay
- Fixed a couple of minor build issues

BTW, I wonder what's current status of cinder. Looks like it has not moved in a year or so... But it seems pretty cool and I would like to use it for new projects and possibly improve it.
